### PR TITLE
only get last month of events

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,13 +1,14 @@
 import request from 'superagent'
 
 let base_url = `https://www.googleapis.com/calendar/v3/calendars/`
-let API_KEY = process.env.REACT_APP_GCAL_API_KEY
+let API_KEY = "AIzaSyDNP_uhG02qtAvjGyNsRWQAOvphp94Lldo"
 let CALENDAR_ID = `c55hc7s94pi67k9j16cn85tbas@group.calendar.google.com`
-let event_url = `${base_url}${CALENDAR_ID}/events?key=${API_KEY}`
+let today = new Date()
+let one_month_ago = new Date(today.getFullYear(), today.getMonth() - 1, today.getDay()).toISOString()
+let event_url = `${base_url}${CALENDAR_ID}/events?key=${API_KEY}&timeMin=${one_month_ago}`
 
-
-async function getRecurringEvents(event) {
-    let recurring_event_url = `${base_url}${CALENDAR_ID}/events/${event.id}/instances?key=${API_KEY}&maxResults=50`
+async function getRecurringEvents(event) {\
+    let recurring_event_url = `${base_url}${CALENDAR_ID}/events/${event.id}/instances?key=${API_KEY}&maxResults=50&timeMin=${one_month_ago}`
     const resp = await request.get(recurring_event_url)
     const events = JSON.parse(resp.text).items.map((event) => {
         return {


### PR DESCRIPTION
Too many events are coming back, so limiting the google calendar api to only return events starting from 1 month ago